### PR TITLE
Add Notebook, example of source data file to ScienceBase

### DIFF
--- a/NationalParksIntoSB.ipynb
+++ b/NationalParksIntoSB.ipynb
@@ -1,0 +1,177 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#When working with data within BCB we will first document source information in \n",
+    "#ScienceBase to provide complete traceability of analyses.  This notebook demonstrates the retrieval\n",
+    "#of source data and then the documentation and upload of the source file to the ScienceBase item "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Import Needed Packages\n",
+    "import pysb\n",
+    "import getpass\n",
+    "import time\n",
+    "import urllib.request as ur"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('nps_boundaries.zip', <http.client.HTTPMessage at 0x197425246d8>)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Retrieve source file(s)\n",
+    "\n",
+    "#Define File Url to download\n",
+    "dataUrl = 'http://gstore.unm.edu/apps/rgis/datasets/7bbe8af5-029b-4adf-b06c-134f0dd57226/nps_boundary.original.zip'\n",
+    "\n",
+    "#This is the file actually being used in PAD-US.  This looks similar to that on Data.gov, but is dated as a newer version.  \n",
+    "#When moving past examples need to discuss with PAD team which version to use in moving forward.\n",
+    "#data2Url = 'https://irma.nps.gov/DataStore/DownloadFile/580617'\n",
+    "\n",
+    "#Define output file name\n",
+    "fileName = 'nps_boundaries.zip'\n",
+    "\n",
+    "#Retrieve/Download File\n",
+    "ur.urlretrieve(data2Url, fileName)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Username: dwieferich@usgs.gov\n",
+      "········\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Log in to ScienceBase\n",
+    "loginu=input(\"Username: \")  #asks user for username\n",
+    "sb = pysb.SbSession()\n",
+    "sb.loginc(str(loginu))\n",
+    "time.sleep(2)\n",
+    "\n",
+    "#Create New SB Item, adding zipped shapefile of park boundaries\n",
+    "ret = sb.upload_files_and_create_item(sb.get_my_items_id(), [fileName])\n",
+    "SbItem = ret['id']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "59c284b7e4b091459a61d2d2\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Print Newly Created ScienceBase Item\n",
+    "print(SbItem)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Variables to populate the metadata in the SB Item\n",
+    "\n",
+    "#Retrieve Acquisition Date\n",
+    "import datetime\n",
+    "dNow = datetime.datetime.now()\n",
+    "AcqDate = dNow.strftime(\"%Y-%m-%d\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#JSON used to update SB Item\n",
+    "UpdateItem = {'id': SbItem,\n",
+    "              'title': 'National Park Boundaries 20140625',\n",
+    "              'body': 'National Park Boundaries, this is a test item that shows how we can use code to incorporate data into the BIS',\n",
+    "              'purpose': 'This item is intended to preseve specific versions of files being used in the Biogeographic Information System.',\n",
+    "              'dates': [{'type': 'Acquisition', 'dateString': AcqDate, 'label': 'Acquisition'}],\n",
+    "              'webLinks': [{\"type\":\"sourceCode\",\"typeLabel\":\"Source Code\",\"uri\":\"https://github.com/dwief-usgs/BCB_Ipython_Notebooks/blob/master/NationalParksIntoSB.ipynb\",\"rel\":\"related\",\"title\":\"Python Code Used to Develop and Populate This SB Item\",\"hidden\":False},{\"type\":\"webLink\",\"typeLabel\":\"Web Link\",\"uri\":\"http://gstore.unm.edu/apps/rgis/datasets/7bbe8af5-029b-4adf-b06c-134f0dd57226/nps_boundary.original.zip\",\"rel\":\"related\",\"title\":\"National Park Boundaries Download URL\",\"hidden\":False}],\n",
+    "              'contacts': [{\"name\":\"Daniel J Wieferich\",\"oldPartyId\":66431,\"type\":\"Contact\",\"contactType\":\"person\",\"email\":\"dwieferich@usgs.gov\",\"active\":True,\"jobTitle\":\"Physical Scientist\",\"firstName\":\"Daniel\",\"middleName\":\"J\",\"lastName\":\"Wieferich\",\"organization\":{\"displayText\":\"Biogeographic Characterization\"},\"primaryLocation\":{\"name\":\"CN=Daniel J Wieferich,OU=CSS,OU=Users,OU=OITS,OU=DI,DC=gs,DC=doi,DC=net - Primary Location\",\"building\":\"DFC Bldg 810\",\"buildingCode\":\"KBT\",\"officePhone\":\"3032024594\",\"faxPhone\":\"3032024710\",\"streetAddress\":{\"line1\":\"W 6th Ave Kipling St\",\"city\":\"Lakewood\",\"state\":\"CO\",\"zip\":\"80225\"},\"mailAddress\":{}},\"orcId\":\"0000-0003-1554-7992\"}],\n",
+    "              \"tags\":[{\"type\":\"Theme\",\"scheme\":\"BIS\",\"name\":\"National Park Boundaries\"},{\"type\":\"Theme\",\"scheme\":\"BIS\",\"name\":\"PAD-US Source\"}]\n",
+    "             }\n",
+    "\n",
+    "#Update SB Item, using above JSON\n",
+    "updateItem = sb.updateSbItem(UpdateItem)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "#Remove local version of date\n",
+    "os.remove(fileName)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Related to the project, "Process Source Files into SFR".   Added a notebook that uses python to retrieve an example source data file and then documents and uploads the file into ScienceBase.  The ScienceBase item can then be used to ensure tracibility to the source data for analytical processes and data management efforts within BCB.  